### PR TITLE
Add teleprompter web interface with scrolling, mirroring, and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Teleprompter</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app">
+    <header>
+      <h1>Teleprompter Studio</h1>
+      <p>Enter formatted text, then press play to scroll it smoothly.</p>
+    </header>
+
+    <section class="controls">
+      <div class="control-group">
+        <label for="speed">Scroll speed</label>
+        <input id="speed" type="range" min="10" max="200" value="60" />
+        <span id="speedValue">60 px/s</span>
+      </div>
+      <div class="control-group">
+        <label for="fontSize">Text size</label>
+        <input id="fontSize" type="range" min="18" max="80" value="40" />
+        <span id="fontSizeValue">40 px</span>
+      </div>
+      <div class="control-group toggles">
+        <label><input id="alternateLines" type="checkbox" checked /> Alternate line colors</label>
+        <label><input id="flipHorizontal" type="checkbox" /> Flip horizontally</label>
+        <label><input id="flipVertical" type="checkbox" /> Flip vertically</label>
+      </div>
+      <div class="control-group buttons">
+        <button id="playButton" type="button">Play</button>
+        <button id="pauseButton" type="button" disabled>Pause</button>
+        <button id="resetButton" type="button">Reset</button>
+      </div>
+    </section>
+
+    <section class="editor">
+      <div class="editor-pane">
+        <h2>Script</h2>
+        <div
+          id="scriptInput"
+          class="script-input"
+          contenteditable="true"
+          spellcheck="true"
+        >
+          <div>Welcome to your teleprompter.</div>
+          <div><strong>Bold</strong>, <em>italic</em>, and <u>underlined</u> text is supported.</div>
+          <div>Use line breaks to pace your delivery.</div>
+          <div>Use the mirror toggles for reflective setups.</div>
+        </div>
+        <p class="hint">Tip: Use Enter for a new line. Formatting shortcuts (Ctrl/Cmd + B/I/U) work here.</p>
+      </div>
+      <div class="preview-pane">
+        <h2>Teleprompter Preview</h2>
+        <div id="teleprompter" class="teleprompter">
+          <div id="teleprompterContent" class="teleprompter-content"></div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,139 @@
+const scriptInput = document.getElementById("scriptInput");
+const teleprompter = document.getElementById("teleprompter");
+const teleprompterContent = document.getElementById("teleprompterContent");
+const speedInput = document.getElementById("speed");
+const speedValue = document.getElementById("speedValue");
+const fontSizeInput = document.getElementById("fontSize");
+const fontSizeValue = document.getElementById("fontSizeValue");
+const alternateLinesInput = document.getElementById("alternateLines");
+const flipHorizontalInput = document.getElementById("flipHorizontal");
+const flipVerticalInput = document.getElementById("flipVertical");
+const playButton = document.getElementById("playButton");
+const pauseButton = document.getElementById("pauseButton");
+const resetButton = document.getElementById("resetButton");
+
+let offset = 0;
+let lastFrameTime = null;
+let isPlaying = false;
+
+const ensureLineNodes = () => {
+  const lines = [];
+  const childNodes = Array.from(scriptInput.childNodes).filter(
+    (node) => node.nodeType !== Node.COMMENT_NODE
+  );
+
+  if (childNodes.length === 0) {
+    return [""].map((text) => ({ text }));
+  }
+
+  childNodes.forEach((node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent || "";
+      text.split(/\n/).forEach((line) => lines.push({ text: line }));
+      return;
+    }
+
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      if (node.tagName === "BR") {
+        lines.push({ text: "" });
+        return;
+      }
+
+      lines.push({ node: node.cloneNode(true) });
+    }
+  });
+
+  return lines.length ? lines : [{ text: "" }];
+};
+
+const renderTeleprompter = () => {
+  teleprompterContent.innerHTML = "";
+  const lines = ensureLineNodes();
+
+  lines.forEach((line) => {
+    const lineElement = document.createElement("div");
+    lineElement.classList.add("line");
+    if (line.node) {
+      lineElement.appendChild(line.node);
+    } else {
+      lineElement.textContent = line.text;
+    }
+    teleprompterContent.appendChild(lineElement);
+  });
+
+  teleprompterContent.classList.toggle(
+    "alternate",
+    alternateLinesInput.checked
+  );
+};
+
+const updateSpeed = () => {
+  speedValue.textContent = `${speedInput.value} px/s`;
+};
+
+const updateFontSize = () => {
+  fontSizeValue.textContent = `${fontSizeInput.value} px`;
+  document.documentElement.style.setProperty(
+    "--font-size",
+    `${fontSizeInput.value}px`
+  );
+};
+
+const updateMirroring = () => {
+  teleprompter.classList.toggle("flip-horizontal", flipHorizontalInput.checked);
+  teleprompter.classList.toggle("flip-vertical", flipVerticalInput.checked);
+};
+
+const updateScroll = (timestamp) => {
+  if (!isPlaying) {
+    lastFrameTime = null;
+    return;
+  }
+
+  if (lastFrameTime === null) {
+    lastFrameTime = timestamp;
+  }
+
+  const deltaSeconds = (timestamp - lastFrameTime) / 1000;
+  lastFrameTime = timestamp;
+  offset -= Number(speedInput.value) * deltaSeconds;
+  teleprompterContent.style.setProperty("--scroll-offset", `${offset}px`);
+
+  requestAnimationFrame(updateScroll);
+};
+
+const play = () => {
+  if (isPlaying) return;
+  isPlaying = true;
+  playButton.disabled = true;
+  pauseButton.disabled = false;
+  requestAnimationFrame(updateScroll);
+};
+
+const pause = () => {
+  isPlaying = false;
+  playButton.disabled = false;
+  pauseButton.disabled = true;
+};
+
+const reset = () => {
+  offset = 0;
+  teleprompterContent.style.setProperty("--scroll-offset", "0px");
+};
+
+scriptInput.addEventListener("input", renderTeleprompter);
+scriptInput.addEventListener("blur", renderTeleprompter);
+
+speedInput.addEventListener("input", updateSpeed);
+fontSizeInput.addEventListener("input", updateFontSize);
+alternateLinesInput.addEventListener("change", renderTeleprompter);
+flipHorizontalInput.addEventListener("change", updateMirroring);
+flipVerticalInput.addEventListener("change", updateMirroring);
+playButton.addEventListener("click", play);
+pauseButton.addEventListener("click", pause);
+resetButton.addEventListener("click", reset);
+
+updateSpeed();
+updateFontSize();
+updateMirroring();
+renderTeleprompter();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,203 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  --bg: #0c0f14;
+  --panel: #151a22;
+  --panel-alt: #1f2632;
+  --text: #eef3ff;
+  --muted: #98a3b8;
+  --accent: #5fd1ff;
+  --accent-strong: #2b92ff;
+  --line-alt: rgba(95, 209, 255, 0.3);
+  --font-size: 40px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #182030, var(--bg));
+  color: var(--text);
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+header {
+  margin-bottom: 24px;
+}
+
+header h1 {
+  margin: 0 0 8px;
+  font-size: 32px;
+}
+
+header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  background: var(--panel);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.control-group span {
+  font-size: 14px;
+  color: var(--accent);
+}
+
+.control-group input[type="range"] {
+  width: 100%;
+}
+
+.toggles label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--text);
+}
+
+.buttons {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 18px;
+  font-weight: 600;
+  background: var(--accent-strong);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.editor {
+  margin-top: 24px;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.editor-pane,
+.preview-pane {
+  background: var(--panel);
+  padding: 20px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.editor-pane h2,
+.preview-pane h2 {
+  margin-top: 0;
+  font-size: 18px;
+}
+
+.script-input {
+  background: var(--panel-alt);
+  padding: 16px;
+  min-height: 260px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  outline: none;
+  line-height: 1.6;
+}
+
+.script-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(95, 209, 255, 0.2);
+}
+
+.script-input div {
+  margin-bottom: 8px;
+}
+
+.hint {
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.teleprompter {
+  position: relative;
+  height: 420px;
+  background: #040608;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.teleprompter-content {
+  width: 100%;
+  padding: 40px 32px;
+  font-size: var(--font-size);
+  line-height: 1.6;
+  transform: translateY(var(--scroll-offset, 0px));
+  will-change: transform;
+}
+
+.teleprompter-content .line {
+  margin-bottom: 12px;
+}
+
+.teleprompter-content.alternate .line:nth-child(even) {
+  color: var(--line-alt);
+}
+
+.teleprompter.flip-horizontal .teleprompter-content {
+  transform: scaleX(-1) translateY(var(--scroll-offset, 0px));
+}
+
+.teleprompter.flip-vertical .teleprompter-content {
+  transform: scaleY(-1) translateY(var(--scroll-offset, 0px));
+}
+
+.teleprompter.flip-horizontal.flip-vertical .teleprompter-content {
+  transform: scale(-1) translateY(var(--scroll-offset, 0px));
+}
+
+@media (max-width: 900px) {
+  .controls {
+    grid-template-columns: 1fr;
+  }
+  .buttons {
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight teleprompter web app that accepts formatted text and displays it in a smooth scrolling preview. 
- Support adjustable scroll speed and font size, alternating line colors for readability, and horizontal/vertical mirroring for reflective glass setups.

### Description
- Add `index.html` which provides the editor, controls (speed, font size, alternate-line toggle, mirror toggles) and a preview pane. 
- Add `styles.css` which implements a dark, responsive UI, alternating line coloring, and mirroring transforms; it exposes `--font-size` and `--scroll-offset` CSS variables. 
- Add `script.js` which parses and preserves formatted lines from the contenteditable editor, renders per-line nodes, implements the scroll animation via `requestAnimationFrame` and `--scroll-offset`, and wires up play/pause/reset, speed/size controls, and mirroring toggles.

### Testing
- Served the site locally using `python -m http.server 8000` and verified the app responded successfully. 
- Ran a Playwright script to open `http://127.0.0.1:8000` and capture a screenshot which produced `artifacts/teleprompter.png`, confirming the UI rendered as expected. 
- Committed the three new files (`index.html`, `styles.css`, `script.js`) to the repository; no automated unit tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b9c48c0c0832692e0614810b12c25)