### PR TITLE
Add selectable alternate line color and full-size output overlay with controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
         <input id="fontSize" type="range" min="18" max="80" value="40" />
         <span id="fontSizeValue">40 px</span>
       </div>
+      <div class="control-group">
+        <label for="alternateColor">Alternate line color</label>
+        <input id="alternateColor" type="color" value="#5fd1ff" />
+        <span id="alternateColorValue">#5FD1FF</span>
+      </div>
       <div class="control-group toggles">
         <label><input id="alternateLines" type="checkbox" checked /> Alternate line colors</label>
         <label><input id="flipHorizontal" type="checkbox" /> Flip horizontally</label>
@@ -33,6 +38,7 @@
         <button id="playButton" type="button">Play</button>
         <button id="pauseButton" type="button" disabled>Pause</button>
         <button id="resetButton" type="button">Reset</button>
+        <button id="openOutputButton" type="button">Open Output</button>
       </div>
     </section>
 
@@ -59,6 +65,30 @@
         </div>
       </div>
     </section>
+  </div>
+
+  <div id="outputOverlay" class="output-overlay" hidden>
+    <div class="output-controls">
+      <div class="output-controls-group">
+        <button id="outputPlayButton" type="button">Play</button>
+        <button id="outputPauseButton" type="button" disabled>Pause</button>
+        <button id="outputResetButton" type="button">Reset</button>
+      </div>
+      <div class="output-controls-group">
+        <label for="outputSpeed">Speed</label>
+        <input id="outputSpeed" type="range" min="10" max="200" value="60" />
+        <span id="outputSpeedValue">60 px/s</span>
+      </div>
+      <div class="output-controls-group">
+        <label for="outputFontSize">Size</label>
+        <input id="outputFontSize" type="range" min="18" max="80" value="40" />
+        <span id="outputFontSizeValue">40 px</span>
+      </div>
+      <button id="closeOutputButton" class="output-close" type="button">Close</button>
+    </div>
+    <div id="outputTeleprompter" class="teleprompter output-teleprompter">
+      <div id="outputTeleprompterContent" class="teleprompter-content"></div>
+    </div>
   </div>
 
   <script src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,10 @@ body {
   color: var(--text);
 }
 
+body.output-open {
+  overflow: hidden;
+}
+
 .app {
   max-width: 1200px;
   margin: 0 auto;
@@ -70,6 +74,16 @@ header p {
 
 .control-group input[type="range"] {
   width: 100%;
+}
+
+.control-group input[type="color"] {
+  width: 100%;
+  height: 40px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
 }
 
 .toggles label {
@@ -193,11 +207,75 @@ button:hover:not(:disabled) {
   transform: scale(-1) translateY(var(--scroll-offset, 0px));
 }
 
+.output-overlay {
+  position: fixed;
+  inset: 0;
+  background: #040608;
+  display: flex;
+  flex-direction: column;
+  z-index: 20;
+}
+
+.output-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 24px;
+  background: rgba(21, 26, 34, 0.95);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.output-controls-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text);
+}
+
+.output-controls-group label {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.output-controls-group span {
+  font-size: 13px;
+  color: var(--accent);
+}
+
+.output-controls-group input[type="range"] {
+  width: 160px;
+}
+
+.output-close {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.output-teleprompter {
+  flex: 1;
+  height: auto;
+  border-radius: 0;
+  border: none;
+}
+
+.output-teleprompter .teleprompter-content {
+  padding: 80px 72px;
+}
+
 @media (max-width: 900px) {
   .controls {
     grid-template-columns: 1fr;
   }
   .buttons {
     justify-content: flex-start;
+  }
+  .output-controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .output-close {
+    margin-left: 0;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a way to customize the alternate-line highlight color and offer a dedicated full-size output view for presentations with independent playback, speed and size controls.

### Description
- Added a color picker and display (`#alternateColor`, `#alternateColorValue`) in `index.html` and implemented `updateAlternateColor` and `hexToRgba` in `script.js` to update the `--line-alt` CSS variable.
- Introduced a full-size output overlay (`#outputOverlay`, `#outputTeleprompter`, `#outputTeleprompterContent`) with its own controls in `index.html` and corresponding styles in `styles.css` (`.output-overlay`, `.output-controls`, `.output-teleprompter`), and locked page scrolling with `body.output-open` while open.
- Synchronized main and output controls via `syncSpeed` and `syncFontSize`, shared playback functions (`play`, `pause`, `reset`), and unified scroll offset using `setScrollOffset`, and cloned the rendered lines into the output view in `renderTeleprompter`.
- Mirroring toggles (`flipHorizontal`, `flipVertical`) and alternate-line toggles are applied to both preview and output views and CSS variables drive the alternate-line color.

### Testing
- Started a local static server with `python -m http.server` which served the files successfully.
- Attempted to capture a screenshot using Playwright to validate the overlay, but the Playwright run timed out (failed).
- No automated unit tests were added or run; basic smoke interactions were exercised in-browser where possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba678fd6c8326997abb6d57fa3bbd)