### PR TITLE
Add toggle controls for full-screen output and centralize overlay logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,14 @@
         <button id="playButton" type="button">Play</button>
         <button id="pauseButton" type="button" disabled>Pause</button>
         <button id="resetButton" type="button">Reset</button>
-        <button id="openOutputButton" type="button">Open Output</button>
+        <button
+          id="openOutputButton"
+          type="button"
+          aria-controls="outputOverlay"
+          aria-expanded="false"
+        >
+          Full Screen Output
+        </button>
       </div>
     </section>
 
@@ -84,7 +91,9 @@
         <input id="outputFontSize" type="range" min="18" max="80" value="40" />
         <span id="outputFontSizeValue">40 px</span>
       </div>
-      <button id="closeOutputButton" class="output-close" type="button">Close</button>
+      <button id="closeOutputButton" class="output-close" type="button">
+        Back to Options
+      </button>
     </div>
     <div id="outputTeleprompter" class="teleprompter output-teleprompter">
       <div id="outputTeleprompterContent" class="teleprompter-content"></div>

--- a/script.js
+++ b/script.js
@@ -191,15 +191,14 @@ const syncFontSize = (value) => {
   updateFontSize();
 };
 
-const openOutput = () => {
-  outputOverlay.hidden = false;
-  document.body.classList.add("output-open");
+const setOutputOpen = (shouldOpen) => {
+  outputOverlay.hidden = !shouldOpen;
+  document.body.classList.toggle("output-open", shouldOpen);
+  openOutputButton.setAttribute("aria-expanded", String(shouldOpen));
 };
 
-const closeOutput = () => {
-  outputOverlay.hidden = true;
-  document.body.classList.remove("output-open");
-};
+const openOutput = () => setOutputOpen(true);
+const closeOutput = () => setOutputOpen(false);
 
 scriptInput.addEventListener("input", renderTeleprompter);
 scriptInput.addEventListener("blur", renderTeleprompter);
@@ -227,8 +226,15 @@ outputPlayButton.addEventListener("click", play);
 outputPauseButton.addEventListener("click", pause);
 outputResetButton.addEventListener("click", reset);
 
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && !outputOverlay.hidden) {
+    closeOutput();
+  }
+});
+
 syncSpeed(speedInput.value);
 syncFontSize(fontSizeInput.value);
 updateAlternateColor();
 updateMirroring();
 renderTeleprompter();
+setOutputOpen(!outputOverlay.hidden);


### PR DESCRIPTION
### Motivation
- Restore the ability to switch between the options/editor view and the full-screen teleprompter output so users can toggle views reliably. 
- Make the overlay toggle accessible and explicit by labeling controls and adding ARIA attributes. 
- Centralize open/close behavior to ensure consistent state updates and to provide keyboard (Escape) support for closing the output view.

### Description
- Changed the output open button label to `Full Screen Output` and added `aria-controls="outputOverlay"` and `aria-expanded="false"` in `index.html`. 
- Renamed the overlay close button to `Back to Options` in `index.html` to clarify its purpose. 
- Introduced `setOutputOpen(shouldOpen)` in `script.js` which toggles `outputOverlay.hidden`, updates the `body.output-open` class, and writes `aria-expanded` on the opener. 
- Replaced the previous `openOutput`/`closeOutput` logic to call `setOutputOpen`, added an `Escape` key handler to close the overlay, and initialize overlay state with `setOutputOpen(!outputOverlay.hidden)`.

### Testing
- Launched a static server with `python -m http.server 8000` which started successfully. 
- Verified the updated button exists in the served HTML using `curl` which returned the expected `openOutputButton` element. 
- Ran an automated Playwright script attempting to open the overlay and capture a screenshot, but the headless browser timed out/crashed in this environment so the Playwright test failed. 
- No unit tests exist for this UI-only change; changes are limited to static HTML/CSS/JS updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697baa3cce7483269563fc5dbbc0fbc8)