### PR TITLE
Fix output overlay hidden state on load

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -216,6 +216,10 @@ button:hover:not(:disabled) {
   z-index: 20;
 }
 
+.output-overlay[hidden] {
+  display: none;
+}
+
 .output-controls {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
### Motivation
- The full-screen output overlay was always visible due to its default `display` rule, so the app started on the teleprompter output instead of the options screen and the "Back to Options" flow didn't hide it as expected.

### Description
- Add a rule `.output-overlay[hidden] { display: none; }` to `styles.css` so the overlay respects the `hidden` attribute and the options screen is shown by default.

### Testing
- Launched a local server with `python -m http.server 8000` and ran a Playwright script to open `http://127.0.0.1:8000/` which produced `artifacts/teleprompter-options.png`, confirming the options screen is visible (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697babb364408326a31c870bf97a040e)