### PR TITLE
Use exact hex for alternate line color (remove dimming)

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,22 +84,6 @@ const renderTeleprompter = () => {
   });
 };
 
-const hexToRgba = (hex, alpha) => {
-  const cleanHex = hex.replace("#", "");
-  const fullHex =
-    cleanHex.length === 3
-      ? cleanHex
-          .split("")
-          .map((char) => char + char)
-          .join("")
-      : cleanHex;
-  const int = Number.parseInt(fullHex, 16);
-  const r = (int >> 16) & 255;
-  const g = (int >> 8) & 255;
-  const b = int & 255;
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-};
-
 const updateSpeed = () => {
   speedValue.textContent = `${speedInput.value} px/s`;
   outputSpeedValue.textContent = `${outputSpeedInput.value} px/s`;
@@ -116,8 +100,10 @@ const updateFontSize = () => {
 
 const updateAlternateColor = () => {
   alternateColorValue.textContent = alternateColorInput.value.toUpperCase();
-  const rgba = hexToRgba(alternateColorInput.value, 0.35);
-  document.documentElement.style.setProperty("--line-alt", rgba);
+  document.documentElement.style.setProperty(
+    "--line-alt",
+    alternateColorInput.value
+  );
 };
 
 const updateMirroring = () => {


### PR DESCRIPTION
### Motivation
- Alternate line color was appearing darker because the code converted the chosen hex to an `rgba(...)` with alpha `0.35`, effectively dimming the color.

### Description
- Remove the hex-to-rgba conversion and instead set the `--line-alt` CSS variable directly to the selected hex value in `updateAlternateColor`.
- Delete the unused `hexToRgba` helper and simplify the alternate color update logic in `script.js`.

### Testing
- Started a local server with `python -m http.server 8000` and captured a page screenshot via Playwright to verify the alternate color rendering (`artifacts/alternate-color.png`) which completed successfully.
- Earlier Playwright attempts that tried to interact with the editable input timed out, but the final load-and-screenshot run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bacc386d88326a393bcaec5842502)