### PR TITLE
Render teleprompter colors in output

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,6 +62,16 @@ const ensureLineNodes = () => {
   return lines.length ? lines : [{ text: "" }];
 };
 
+const stripInlineColor = (node) => {
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return;
+  }
+
+  node.style.color = "";
+  node.removeAttribute("color");
+  Array.from(node.children).forEach(stripInlineColor);
+};
+
 const renderTeleprompter = () => {
   teleprompterContent.innerHTML = "";
   outputTeleprompterContent.innerHTML = "";
@@ -75,8 +85,11 @@ const renderTeleprompter = () => {
     } else {
       lineElement.textContent = line.text;
     }
+    stripInlineColor(lineElement);
     teleprompterContent.appendChild(lineElement);
-    outputTeleprompterContent.appendChild(lineElement.cloneNode(true));
+    const outputLine = lineElement.cloneNode(true);
+    stripInlineColor(outputLine);
+    outputTeleprompterContent.appendChild(outputLine);
   });
 
   [teleprompterContent, outputTeleprompterContent].forEach((content) => {

--- a/styles.css
+++ b/styles.css
@@ -189,10 +189,19 @@ button:hover:not(:disabled) {
 
 .teleprompter-content .line {
   margin-bottom: 12px;
+  color: var(--text);
+}
+
+.teleprompter-content .line * {
+  color: inherit;
 }
 
 .teleprompter-content.alternate .line:nth-child(even) {
   color: var(--line-alt);
+}
+
+.teleprompter-content.alternate .line:nth-child(even) * {
+  color: inherit;
 }
 
 .teleprompter.flip-horizontal .teleprompter-content {


### PR DESCRIPTION
### Motivation
- Pasted or formatted input could carry inline `style.color` or `color` attributes into the teleprompter, which prevented the theme and alternate-line colors from reliably controlling rendered text colors.

### Description
- Move `stripInlineColor` out of `ensureLineNodes` and perform inline-color stripping during the render pass so colors are enforced at render time for visible elements.
- Call `stripInlineColor` on both the preview `lineElement` and the cloned `outputLine` so both the in-editor preview and the output overlay are sanitized.
- The sanitizer recursively clears `style.color` and `color` attributes from elements so nested formatting cannot override line colors.
- Add CSS rules to set `.teleprompter-content .line { color: var(--text); }` and make descendants inherit via `.teleprompter-content .line * { color: inherit; }` and `.teleprompter-content.alternate .line:nth-child(even) * { color: inherit; }` so theme/alternate colors propagate into nested tags.

### Testing
- Served the app with `python -m http.server` and ran a Playwright script to capture a screenshot, which completed successfully and produced `artifacts/teleprompter-output-color.png`.
- No additional automated unit test suites were present or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb212d0b88326afca952513e8faa5)