### PR TITLE
Sanitize pasted formatting, fix reset scroll, and limit alternating colors to output

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -174,7 +174,7 @@ button:hover:not(:disabled) {
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
 }
 


### PR DESCRIPTION
### Motivation
- Users pasting rich text should lose font size/color but keep bold/italic/underline, and the teleprompter reset must return to the true top of the content.  
- Alternating line color(s) should only affect the fullscreen output view rather than the editor preview.

### Description
- Added paste sanitization: implemented `sanitizePaste`, `sanitizeNode`, and `stripInlineFormatting` to remove inline size/color/face/style while preserving `B/STRONG`, `I/EM`, and `U` spans and text nodes.  
- Added `paste` handler on `scriptInput` to intercept clipboard HTML/plain text and insert a sanitized fragment at the selection.  
- Switched alternating class application to only toggle on the fullscreen output container (`outputTeleprompterContent`) and removed it from the preview (`teleprompterContent`).  
- Reset behavior fixed by clearing `lastFrameTime` in `reset()` so scrolling restarts from the top, and aligned `.teleprompter` content to the top by setting `align-items: flex-start` in `styles.css`.

### Testing
- Launched a local static server with `python -m http.server 8000` and loaded the page, then ran a Playwright script to capture a screenshot of the updated UI, which completed successfully.  
- Verified file changes and committed with `git commit` which succeeded.  
- No unit tests were added; no automated unit test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb73372348326910ef0864abba4ae)