### PR TITLE
Fix alternate line colors in preview

### DIFF
--- a/script.js
+++ b/script.js
@@ -180,7 +180,10 @@ const renderTeleprompter = () => {
     outputTeleprompterContent.appendChild(outputLine);
   });
 
-  teleprompterContent.classList.remove("alternate");
+  teleprompterContent.classList.toggle(
+    "alternate",
+    alternateLinesInput.checked
+  );
   outputTeleprompterContent.classList.toggle(
     "alternate",
     alternateLinesInput.checked


### PR DESCRIPTION
### Motivation
- The preview pane was not applying alternate-line coloring while the full-screen output was, causing inconsistent appearance when `Alternate line colors` is enabled.

### Description
- In `renderTeleprompter` toggle the `alternate` class on the preview container (`teleprompterContent`) based on `alternateLinesInput.checked` so the preview matches the full-screen output (change in `script.js`).

### Testing
- Attempted an automated Playwright run that loads the local server and screenshots the preview, but the script failed with a locator timeout so the UI verification did not complete; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb909bb9083268f07842ab050f85d)